### PR TITLE
Исправлена отправка строк с бинарными данными

### DIFF
--- a/GPRS_Shield_Arduino.cpp
+++ b/GPRS_Shield_Arduino.cpp
@@ -706,7 +706,9 @@ sim900_read_buffer(resp, 96, timeout);
             return 0;
         }*/
             delay(500);
-            sim900_send_cmd(str);
+            for(int i=0; i<len; i++) {
+                sim900_send_byte(str[i]);
+            }
             delay(500);
             sim900_send_End_Mark();
             if(!sim900_wait_for_resp("SEND OK\r\n", DATA, DEFAULT_TIMEOUT * 10, DEFAULT_INTERCHAR_TIMEOUT * 10)) {


### PR DESCRIPTION
Метод send принимает ссылку на строку и длину строки, но в sim900_send_cmd длина строки определяется по первому символу `\0`. Сделана побайтовая отправка строки согласно переданному аргументу len.